### PR TITLE
[Bug][Swap]:  App crashes when Pairs are the same when no wallet

### DIFF
--- a/src/components/Swap/Actions/Swap.tsx
+++ b/src/components/Swap/Actions/Swap.tsx
@@ -258,8 +258,8 @@ const SwapForm: React.FC<FormikProps<SwapFormValues> & {
     }
   }, [modeIn, modeOut, setFieldValue, tokenIn, tokenOut, tokensMatch]);
 
-// if tokenIn && tokenOut are equal and no balances are found, reverse positions. 
-    // This prevents setting of internal balance of given token when there is none
+  // if tokenIn && tokenOut are equal and no balances are found, reverse positions. 
+  // This prevents setting of internal balance of given token when there is none
   const handleTokensEqual = useCallback(() => {
     if (!noBalancesFound) {
       setInitialModes();


### PR DESCRIPTION
https://github.com/BeanstalkFarms/Beanstalk-UI/issues/416

current solution:
If wallet is not connected and newly selected token equates to tokenIn === tokenOut, reverse tokenIn & tokenOut
If wallet address changes / disconnected, reset tokenIn & tokenOut to default settings:
- tokenIn: ETH
- tokenOut: BEAN
- modes (in & out) as EXTERNAL
