### PR TITLE
Copy: Update Almanac URL

### DIFF
--- a/src/components/Balances/SiloBalances.tsx
+++ b/src/components/Balances/SiloBalances.tsx
@@ -237,7 +237,7 @@ const SiloBalances: React.FC<{}> = () => {
                                           }
                                           .{' '}
                                           <Link
-                                            href="https://docs.bean.money/farm/barn#chopping"
+                                            href="https://docs.bean.money/almanac/farm/barn#chopping"
                                             target="_blank"
                                             rel="noreferrer"
                                             underline="hover"

--- a/src/components/Barn/Actions/Buy.tsx
+++ b/src/components/Barn/Actions/Buy.tsx
@@ -154,7 +154,7 @@ const BuyForm : FC<
                   <Divider sx={{ my: 2, opacity: 0.4 }} />
                   <Box sx={{ pb: 1 }}>
                     <Typography variant="body2">
-                      Sprouts become <strong>Rinsable</strong> on a <Link href="https://docs.bean.money/protocol-resources/glossary#pari-passu" target="_blank" rel="noreferrer" underline="hover">pari passu</Link> basis. Upon <strong>Rinse</strong>, each Sprout is redeemed for <span><TokenIcon token={BEAN[1]} css={{ height: IconSize.xs, marginTop: 2.6 }} /></span>1.
+                      Sprouts become <strong>Rinsable</strong> on a <Link href="https://docs.bean.money/almanac/protocol/glossary#pari-passu" target="_blank" rel="noreferrer" underline="hover">pari passu</Link> basis. Upon <strong>Rinse</strong>, each Sprout is redeemed for <span><TokenIcon token={BEAN[1]} css={{ height: IconSize.xs, marginTop: 2.6 }} /></span>1.
                     </Typography>
                   </Box>
                 </TxnAccordion>

--- a/src/components/Common/Form/TokenSelectDialog.tsx
+++ b/src/components/Common/Form/TokenSelectDialog.tsx
@@ -192,7 +192,7 @@ const TokenSelectDialog : TokenSelectDialogC = React.memo(({
           {_balances ? (
             <Typography ml={1} pt={0.5} textAlign="center" fontSize={FontSize.sm} color="gray">
               Displaying total Farm and Circulating balances.&nbsp;
-              <Link href="https://docs.bean.money/protocol-resources/asset-states" target="_blank" rel="noreferrer" underline="none">
+              <Link href="https://docs.bean.money/almanac/protocol/asset-states" target="_blank" rel="noreferrer" underline="none">
                 Learn more &rarr;
               </Link>
             </Typography>

--- a/src/components/Common/PageHeader.tsx
+++ b/src/components/Common/PageHeader.tsx
@@ -58,7 +58,7 @@ const PageHeader : FC<{
               {props.description}.
               {props.href !== undefined && (
                 <Link
-                  href={props.href || 'https://docs.bean.money'}
+                  href={props.href || 'https://docs.bean.money/almanac'}
                   underline="none"
                   color="primary"
                   display="flex"

--- a/src/components/Farmer/Unripe/PickDialog.tsx
+++ b/src/components/Farmer/Unripe/PickDialog.tsx
@@ -273,7 +273,7 @@ const PickBeansDialog: FC<{
         <Typography sx={{ fontSize: '15px' }} color="text.secondary">
           To claim non-Deposited Unripe Beans and Unripe BEAN:3CRV LP, they must be Picked. After Replant, you can Pick assets to your wallet, or Pick and Deposit them directly in the Silo.<br /><br />
           Unripe Deposited assets <b>do not need to be Picked</b> and will be automatically Deposited at Replant.<br /><br />
-          Read more about Unripe assets <Link href="https://docs.bean.money/farm/barn#unripe-assets" target="_blank" rel="noreferrer">here</Link>.
+          Read more about Unripe assets <Link href="https://docs.bean.money/almanac/farm/barn#unripe-assets" target="_blank" rel="noreferrer">here</Link>.
         </Typography>
       </Row>
       <Divider />

--- a/src/components/Field/Actions/Sow.tsx
+++ b/src/components/Field/Actions/Sow.tsx
@@ -191,7 +191,7 @@ const SowForm : FC<
         {!hasSoil ? (
           <Box>
             <Alert color="warning" icon={<IconWrapper boxSize={IconSize.medium}><WarningAmberIcon sx={{ fontSize: IconSize.small }} /></IconWrapper>}>
-              There is currently no Soil. <Link href="https://docs.bean.money/farm/field#soil" target="_blank" rel="noreferrer">Learn more</Link>
+              There is currently no Soil. <Link href="https://docs.bean.money/almanac/farm/field#soil" target="_blank" rel="noreferrer">Learn more</Link>
             </Alert>
           </Box>
         ) : null}
@@ -253,7 +253,7 @@ const SowForm : FC<
                   <Divider sx={{ my: 2, opacity: 0.4 }} />
                   <Box pb={1}>
                     <Typography variant="body2" alignItems="center">
-                      Pods become <strong>Harvestable</strong> on a first in, first out <Link href="https://docs.bean.money/protocol-resources/glossary#fifo" target="_blank" rel="noreferrer" underline="hover">(FIFO)</Link> basis. Upon <strong>Harvest</strong>, each Pod is redeemed for <span><TokenIcon token={BEAN[1]} css={{ height: IconSize.xs, marginTop: 2.6 }} /></span>1.
+                      Pods become <strong>Harvestable</strong> on a first in, first out <Link href="https://docs.bean.money/almanac/protocol/glossary#fifo" target="_blank" rel="noreferrer" underline="hover">(FIFO)</Link> basis. Upon <strong>Harvest</strong>, each Pod is redeemed for <span><TokenIcon token={BEAN[1]} css={{ height: IconSize.xs, marginTop: 2.6 }} /></span>1.
                     </Typography>
                   </Box>
                 </AccordionDetails>

--- a/src/components/Nav/routes.ts
+++ b/src/components/Nav/routes.ts
@@ -83,7 +83,7 @@ const ROUTES : { [key in RouteKeys] : RouteData[] } = {
     },
     {
       path: 'docs',
-      href: 'https://docs.bean.money',
+      href: 'https://docs.bean.money/almanac',
       title: 'Docs',
       icon: docsIcon,
       small: true
@@ -100,7 +100,7 @@ const ROUTES : { [key in RouteKeys] : RouteData[] } = {
     {
       path: 'disclosures',
       title: 'Disclosures',
-      href: 'https://docs.bean.money/disclosures',
+      href: 'https://docs.bean.money/almanac/disclosures',
       icon: disclosuresIcon
     },
     {

--- a/src/components/Silo/SiloAssetApyChip.tsx
+++ b/src/components/Silo/SiloAssetApyChip.tsx
@@ -67,7 +67,7 @@ const SiloAssetApyChip: FC<SiloAssetApyChipProps> = ({ token, metric, variant = 
             ) : (
               <> The Variable Stalk APY estimates the growth in your Stalk balance for Depositing {token.name}.&nbsp; </>
             )}
-            <Link underline="hover" href="https://docs.bean.money/guides/silo/understand-vapy" target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>
+            <Link underline="hover" href="https://docs.bean.money/almanac/guides/silo/understand-vapy" target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>
               Learn more
             </Link>
           </Box>

--- a/src/components/Silo/Whitelist.tsx
+++ b/src/components/Silo/Whitelist.tsx
@@ -99,7 +99,7 @@ const Whitelist : FC<{
               <Tooltip
                 title={
                   <>
-                    <strong>vAPY</strong> (Variable APY) uses historical data about Beans earned by Stalkholders to estimate future returns for Depositing assets in the Silo.&nbsp;<Link underline="hover" href="https://docs.bean.money/guides/silo/understand-vapy" target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>Learn more</Link>
+                    <strong>vAPY</strong> (Variable APY) uses historical data about Beans earned by Stalkholders to estimate future returns for Depositing assets in the Silo.&nbsp;<Link underline="hover" href="https://docs.bean.money/almanac/guides/silo/understand-vapy" target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>Learn more</Link>
                     <Divider sx={{ my: 1 }} />
                     <Typography fontSize={FontSize.sm}>
                       <strong>Bean vAPY:</strong> Estimated annual Beans earned by a Stalkholder for Depositing an asset.<br />
@@ -409,7 +409,7 @@ const Whitelist : FC<{
                                 amount={`1 - ${(unripeTokens[token.address]?.chopPenalty || ZERO_BN).toFixed(4)}%`}
                                 subtitle={
                                   <>
-                                    The current penalty for chopping<br />{token.symbol} for {unripeUnderlyingTokens[token.address].symbol}. <Link href="https://docs.bean.money/farm/barn#chopping" target="_blank" rel="noreferrer" underline="hover" onClick={(e) => { e.stopPropagation(); }}>Learn more</Link>
+                                    The current penalty for chopping<br />{token.symbol} for {unripeUnderlyingTokens[token.address].symbol}. <Link href="https://docs.bean.money/almanac/farm/barn#chopping" target="_blank" rel="noreferrer" underline="hover" onClick={(e) => { e.stopPropagation(); }}>Learn more</Link>
                                   </>
                                 }
                               />

--- a/src/components/Sun/SunriseButton.tsx
+++ b/src/components/Sun/SunriseButton.tsx
@@ -104,7 +104,7 @@ const SunriseButton : FC<{}> = () => {
                           </Row>
                         )}
                         <Row justifyContent="center">
-                          <Typography variant="body1">Reward for calling <Box display="inline" sx={{ backgroundColor: BeanstalkPalette.lightYellow, borderRadius: 0.4, px: 0.4 }}><strong><Link color="text.primary" underline="none" href="https://docs.bean.money/additional-resources/glossary#sunrise" target="_blank" rel="noreferrer">sunrise()</Link></strong></Box>: <TokenIcon token={BEAN[1]} />&nbsp;{displayBN(reward)}</Typography>
+                          <Typography variant="body1">Reward for calling <Box display="inline" sx={{ backgroundColor: BeanstalkPalette.lightYellow, borderRadius: 0.4, px: 0.4 }}><strong><Link color="text.primary" underline="none" href="https://docs.bean.money/almanac/protocol/glossary#sunrise" target="_blank" rel="noreferrer">sunrise()</Link></strong></Box>: <TokenIcon token={BEAN[1]} />&nbsp;{displayBN(reward)}</Typography>
                         </Row>
                       </Stack>
                     </Stack>

--- a/src/pages/barn.tsx
+++ b/src/pages/barn.tsx
@@ -15,7 +15,7 @@ const Barn: FC<{}> = () => (
       <PageHeader
         title="The Barn"
         description="Earn yield and recapitalize Beanstalk with Fertilizer"
-        href="https://docs.bean.money/farm/barn"
+        href="https://docs.bean.money/almanac/farm/barn"
         OuterStackProps={{ direction: 'row' }}
         control={
           <GuideButton

--- a/src/pages/chop.tsx
+++ b/src/pages/chop.tsx
@@ -17,7 +17,7 @@ const ChopPage: FC<{}> = () => (
       <PageHeader 
         title="Chop" 
         description="Burn your Unripe assets for the underlying Ripe assets" 
-        href="https://docs.bean.money/farm/barn#chopping"
+        href="https://docs.bean.money/almanac/farm/barn#chopping"
         OuterStackProps={{ direction: 'row' }}
         control={
           <GuideButton

--- a/src/pages/field.tsx
+++ b/src/pages/field.tsx
@@ -84,7 +84,7 @@ const FieldPage: FC<{}> = () => {
         <PageHeader
           title="The Field"
           description="Earn yield by lending Beans to Beanstalk"
-          href="https://docs.bean.money/farm/field"
+          href="https://docs.bean.money/almanac/farm/field"
           OuterStackProps={{ direction: 'row' }}
           control={
             <GuideButton

--- a/src/pages/governance/index.tsx
+++ b/src/pages/governance/index.tsx
@@ -17,7 +17,7 @@ const GovernancePage: FC<{}> = () => (
       <PageHeader
         title="Governance"
         description="Participate in Beanstalk governance as a Stalkholder"
-        href="https://docs.bean.money/governance/proposals"
+        href="https://docs.bean.money/almanac/governance/proposals"
         control={
           <GuideButton
             title="The Farmers' Almanac: Governance Guides"

--- a/src/pages/market/pods/index.tsx
+++ b/src/pages/market/pods/index.tsx
@@ -26,7 +26,7 @@ const PodMarketPage: FC<{}> = () => {
         <PageHeader
           title="The Pod Market"
           description="Trade the Beanstalk-native debt asset"
-          href="https://docs.bean.money/farm/market#the-pod-market"
+          href="https://docs.bean.money/almanac/farm/market#the-pod-market"
           OuterStackProps={{
             // alignItems: 'end'
           }}

--- a/src/pages/nft.tsx
+++ b/src/pages/nft.tsx
@@ -240,7 +240,7 @@ const NFTPage: FC<{}> = () => {
         <PageHeader
           title="BeaNFTs"
           description="View and mint your BeaNFTs"
-          href="https://docs.bean.money/ecosystem/beanfts"
+          href="https://docs.bean.money/almanac/ecosystem/beanfts"
           control={
             <GuideButton
               title="The Farmers' Almanac: BeaNFT Guides"

--- a/src/pages/silo/index.tsx
+++ b/src/pages/silo/index.tsx
@@ -60,7 +60,7 @@ const SiloPage : FC<{}> = () => {
         <PageHeader
           title="The Silo"
           description="Earn yield and participate in Beanstalk governance by depositing whitelisted assets"
-          href="https://docs.bean.money/farm/silo"
+          href="https://docs.bean.money/almanac/farm/silo"
           // makes guide display to the right of the title on mobile
           OuterStackProps={{ direction: 'row' }}
           control={

--- a/src/pages/swap.tsx
+++ b/src/pages/swap.tsx
@@ -15,7 +15,7 @@ const SwapPage: FC<{}> = () => (
       <PageHeader
         title="Swap"
         description="Trade Beans and transfer Beanstalk assets"
-        href="https://docs.bean.money/guides/swap"
+        href="https://docs.bean.money/almanac/guides/swap"
         control={
           <GuideButton
             title="The Farmers' Almanac: Swap Guides"

--- a/src/util/Guides.ts
+++ b/src/util/Guides.ts
@@ -6,101 +6,101 @@ export type Guide = {
 // SILO
 export const CLAIM_SILO_REWARDS: Guide = {
   title: 'How to Claim Silo Rewards',
-  url: 'https://docs.bean.money/guides/silo/claim-rewards'
+  url: 'https://docs.bean.money/almanac/guides/silo/claim-rewards'
 };
 export const HOW_TO_DEPOSIT_IN_THE_SILO: Guide = {
   title: 'How to Deposit in the Silo',
-  url: 'https://docs.bean.money/guides/silo/deposit'
+  url: 'https://docs.bean.money/almanac/guides/silo/deposit'
 };
 export const HOW_TO_CONVERT_DEPOSITS: Guide = {
   title: 'How to Convert Deposits',
-  url: 'https://docs.bean.money/guides/silo/convert'
+  url: 'https://docs.bean.money/almanac/guides/silo/convert'
 };
 export const HOW_TO_WITHDRAW_FROM_THE_SILO: Guide = {
   title: 'How to Withdraw from the Silo',
-  url: 'https://docs.bean.money/guides/silo/withdraw'
+  url: 'https://docs.bean.money/almanac/guides/silo/withdraw'
 };
 export const HOW_TO_CLAIM_WITHDRAWALS: Guide = {
   title: 'How to Claim Withdrawals',
-  url: 'https://docs.bean.money/guides/silo/claim-assets'
+  url: 'https://docs.bean.money/almanac/guides/silo/claim-assets'
 };
 export const HOW_TO_TRANSFER_DEPOSITS: Guide = {
   title: 'How to Transfer Deposits',
-  url: 'https://docs.bean.money/guides/silo/transfer'
+  url: 'https://docs.bean.money/almanac/guides/silo/transfer'
 };
 
 // FIELD
 export const HOW_TO_SOW_BEANS: Guide = {
   title: 'How to Sow Beans',
-  url: 'https://docs.bean.money/guides/field/sow'
+  url: 'https://docs.bean.money/almanac/guides/field/sow'
 };
 export const HOW_TO_TRANSFER_PODS: Guide = {
   title: 'How to Transfer Pods',
-  url: 'https://docs.bean.money/guides/field/transfer'
+  url: 'https://docs.bean.money/almanac/guides/field/transfer'
 };
 export const HOW_TO_HARVEST_PODS: Guide = {
   title: 'How to Harvest Pods',
-  url: 'https://docs.bean.money/guides/field/harvest'
+  url: 'https://docs.bean.money/almanac/guides/field/harvest'
 };
 
 // BARN
 export const HOW_TO_BUY_FERTILIZER: Guide = {
   title: 'How to Buy Fertilizer',
-  url: 'https://docs.bean.money/guides/barn/buy-fertilizer'
+  url: 'https://docs.bean.money/almanac/guides/barn/buy-fertilizer'
 };
 export const HOW_TO_RINSE_SPROUTS: Guide = {
   title: 'How to Rinse Sprouts',
-  url: 'https://docs.bean.money/guides/barn/rinse'
+  url: 'https://docs.bean.money/almanac/guides/barn/rinse'
 };
 export const HOW_TO_TRANSFER_FERTILIZER: Guide = {
   title: 'How to Transfer Fertilizer',
-  url: 'https://docs.bean.money/guides/barn/transfer-fertilizer'
+  url: 'https://docs.bean.money/almanac/guides/barn/transfer-fertilizer'
 };
 export const HOW_TO_TRADE_FERTILIZER: Guide = {
   title: 'How to Trade Fertilizer',
-  url: 'https://docs.bean.money/guides/barn/trade-fertilizer'
+  url: 'https://docs.bean.money/almanac/guides/barn/trade-fertilizer'
 };
 
 // MARKET
 export const HOW_TO_BUY_PODS: Guide = {
   title: 'How to Buy Pods',
-  url: 'https://docs.bean.money/guides/market/buy-pods'
+  url: 'https://docs.bean.money/almanac/guides/market/buy-pods'
 };
 export const HOW_TO_SELL_PODS: Guide = {
   title: 'How to Sell Pods',
-  url: 'https://docs.bean.money/guides/market/sell-pods'
+  url: 'https://docs.bean.money/almanac/guides/market/sell-pods'
 };
 
 // BALANCES
 export const HOW_TO_UNDERSTAND_BALANCES: Guide = {
   title: 'How to Understand My Balances',
-  url: 'https://docs.bean.money/guides/balances/understand-my-balances'
+  url: 'https://docs.bean.money/almanac/guides/balances/understand-my-balances'
 };
 
 // BEANFTS
 export const HOW_TO_MINT_BEANFTS: Guide = {
   title: 'How to Mint BeaNFTs',
-  url: 'https://docs.bean.money/guides/beanfts/mint-beanfts'
+  url: 'https://docs.bean.money/almanac/guides/beanfts/mint-beanfts'
 };
 
 // SWAP
 export const HOW_TO_TRADE_BEANS: Guide = {
   title: 'How to Trade Beans',
-  url: 'https://docs.bean.money/guides/swap/trade-beans'
+  url: 'https://docs.bean.money/almanac/guides/swap/trade-beans'
 };
 export const HOW_TO_TRANSFER_FARM_BALANCE: Guide = {
   title: 'How to Transfer Farm Balances',
-  url: 'https://docs.bean.money/guides/swap/transfer-farm-balance'
+  url: 'https://docs.bean.money/almanac/guides/swap/transfer-farm-balance'
 };
 
 // GOVERNANCE
 export const HOW_TO_VOTE: Guide = {
   title: 'How to Vote on Governance Proposals',
-  url: 'https://docs.bean.money/guides/governance/vote-on-proposals'
+  url: 'https://docs.bean.money/almanac/guides/governance/vote-on-proposals'
 };
 
 /// CHOP
 export const HOW_TO_CHOP_UNRIPE_BEANS: Guide = {
   title: 'How to Chop Unripe Beans',
-  url: 'https://docs.bean.money/guides/unripe-assets/chop-unripe-assets'
+  url: 'https://docs.bean.money/almanac/guides/unripe-assets/chop-unripe-assets'
 };


### PR DESCRIPTION
All old URLs already redirect to https://docs.bean.money/almanac, but updating the links for good measure anyway