### PR TITLE
Don’t show bdv in transaction detail for deposit

### DIFF
--- a/src/lib/Beanstalk/Silo/Deposit.ts
+++ b/src/lib/Beanstalk/Silo/Deposit.ts
@@ -69,7 +69,7 @@ export function deposit(
   // DEPOSIT and RECEIVE_REWARDS always come last
   summary.actions.push({
     type: ActionType.DEPOSIT,
-    amount: summary.bdv,
+    amount: summary.amount,
     // from the perspective of the deposit, the token is "coming in".
     token: to, 
   });


### PR DESCRIPTION
The Deposit line in the Transaction Details section shows BDV instead of LP amount. This PR fixes this

![image](https://user-images.githubusercontent.com/99347981/205965881-8b0d5df0-4409-4798-a86e-91bf11cfc91d.png)
